### PR TITLE
Merge assignee and persona concepts - personas ARE the assignees

### DIFF
--- a/src/client/components/CreateTaskModal.tsx
+++ b/src/client/components/CreateTaskModal.tsx
@@ -13,7 +13,6 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ personas, onClose, on
     description: '',
     status: 'backlog' as Task['status'],
     priority: 50,
-    assignee: '',
     persona: '',
     tags: [] as string[],
     dueDate: undefined as Date | undefined,
@@ -29,7 +28,6 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ personas, onClose, on
       description: newTask.description.trim(),
       status: newTask.status,
       priority: newTask.priority,
-      assignee: newTask.assignee.trim() || undefined,
       persona: newTask.persona || undefined,
       tags: newTask.tags,
       dueDate: newTask.dueDate,
@@ -101,31 +99,19 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = ({ personas, onClose, on
               </div>
             </div>
 
-            <div className="form-row">
-              <div className="form-group">
-                <label>Assignee</label>
-                <input
-                  type="email"
-                  value={newTask.assignee}
-                  onChange={(e) => setNewTask({ ...newTask, assignee: e.target.value })}
-                  placeholder="assignee@example.com"
-                />
-              </div>
-
-              <div className="form-group">
-                <label>Persona</label>
-                <select
-                  value={newTask.persona}
-                  onChange={(e) => setNewTask({ ...newTask, persona: e.target.value })}
-                >
-                  <option value="">No Persona</option>
-                  {personas.map(persona => (
-                    <option key={persona.id} value={persona.id}>
-                      {persona.emoji} {persona.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            <div className="form-group">
+              <label>Assign to Persona</label>
+              <select
+                value={newTask.persona}
+                onChange={(e) => setNewTask({ ...newTask, persona: e.target.value })}
+              >
+                <option value="">Unassigned</option>
+                {personas.map(persona => (
+                  <option key={persona.id} value={persona.id}>
+                    {persona.emoji} {persona.name}
+                  </option>
+                ))}
+              </select>
             </div>
 
             <div className="form-row">

--- a/src/client/components/FilterBar.tsx
+++ b/src/client/components/FilterBar.tsx
@@ -16,22 +16,11 @@ const FilterBar: React.FC<FilterBarProps> = ({
   onFilterChange,
   onCreateTask,
 }) => {
-  const uniqueAssignees = Array.from(new Set(tasks.map(t => t.assignee).filter(Boolean)));
   const uniqueTags = Array.from(new Set(tasks.flatMap(t => t.tags)));
 
   return (
     <div className="filter-bar">
       <div className="filter-controls">
-        <select
-          value={filter.assignee || ''}
-          onChange={(e) => onFilterChange({ ...filter, assignee: e.target.value || undefined })}
-        >
-          <option value="">All Assignees</option>
-          {uniqueAssignees.map(assignee => (
-            <option key={assignee} value={assignee}>{assignee}</option>
-          ))}
-        </select>
-
         <select
           value={filter.persona || ''}
           onChange={(e) => onFilterChange({ ...filter, persona: e.target.value || undefined })}
@@ -68,7 +57,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           ))}
         </select>
 
-        {(filter.assignee || filter.persona || filter.status || filter.tags) && (
+        {(filter.persona || filter.status || filter.tags) && (
           <button
             className="clear-filters"
             onClick={() => onFilterChange({})}

--- a/src/client/components/TaskCard.tsx
+++ b/src/client/components/TaskCard.tsx
@@ -41,7 +41,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, personas, onClick, isDragging
           {task.priority}
         </div>
         {persona && (
-          <div className="task-persona" title={persona.name}>
+          <div className="task-assignee" title={`Assigned to ${persona.name}`}>
             {persona.emoji}
           </div>
         )}
@@ -67,12 +67,6 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, personas, onClick, isDragging
             <span className="task-tag-more">+{task.tags.length - 3}</span>
           )}
         </div>
-        
-        {task.assignee && (
-          <div className="task-assignee" title={task.assignee}>
-            {getInitials(task.assignee)}
-          </div>
-        )}
       </div>
     </div>
   );
@@ -83,15 +77,6 @@ function getPriorityColor(priority: number): string {
   if (priority >= 100) return '#f59e0b'; // amber
   if (priority >= 50) return '#10b981'; // emerald
   return '#6b7280'; // gray
-}
-
-function getInitials(email: string): string {
-  const name = email.split('@')[0];
-  return name
-    .split(/[.\-_]/)
-    .map(part => part.charAt(0).toUpperCase())
-    .join('')
-    .slice(0, 2);
 }
 
 export default TaskCard;

--- a/src/client/components/TaskModal.tsx
+++ b/src/client/components/TaskModal.tsx
@@ -83,36 +83,22 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, personas, onClose, onUpdate
                 </div>
               </div>
 
-              <div className="form-row">
-                <div className="form-group">
-                  <label>Assignee</label>
-                  <input
-                    type="email"
-                    value={editedTask.assignee || ''}
-                    onChange={(e) => setEditedTask({ 
-                      ...editedTask, 
-                      assignee: e.target.value || undefined 
-                    })}
-                  />
-                </div>
-
-                <div className="form-group">
-                  <label>Persona</label>
-                  <select
-                    value={editedTask.persona || ''}
-                    onChange={(e) => setEditedTask({ 
-                      ...editedTask, 
-                      persona: e.target.value || undefined 
-                    })}
-                  >
-                    <option value="">No Persona</option>
-                    {personas.map(persona => (
-                      <option key={persona.id} value={persona.id}>
-                        {persona.emoji} {persona.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+              <div className="form-group">
+                <label>Assigned Persona</label>
+                <select
+                  value={editedTask.persona || ''}
+                  onChange={(e) => setEditedTask({ 
+                    ...editedTask, 
+                    persona: e.target.value || undefined 
+                  })}
+                >
+                  <option value="">Unassigned</option>
+                  {personas.map(persona => (
+                    <option key={persona.id} value={persona.id}>
+                      {persona.emoji} {persona.name}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               <div className="form-group">
@@ -136,9 +122,9 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, personas, onClose, onUpdate
                   <span className="task-priority">Priority: {task.priority}</span>
                 </div>
                 {persona && (
-                  <div className="task-persona-badge">
+                  <div className="task-assignee-badge">
                     <span className="persona-emoji">{persona.emoji}</span>
-                    <span className="persona-name">{persona.name}</span>
+                    <span className="persona-name">Assigned to {persona.name}</span>
                   </div>
                 )}
               </div>
@@ -160,7 +146,6 @@ const TaskModal: React.FC<TaskModalProps> = ({ task, personas, onClose, onUpdate
               )}
 
               <div className="task-metadata">
-                {task.assignee && <p><strong>Assignee:</strong> {task.assignee}</p>}
                 <p><strong>Created:</strong> {task.createdAt.toLocaleString()}</p>
                 <p><strong>Updated:</strong> {task.updatedAt.toLocaleString()}</p>
                 {task.dueDate && <p><strong>Due:</strong> {task.dueDate.toLocaleString()}</p>}

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -4,8 +4,7 @@ export interface Task {
   description: string;
   status: 'backlog' | 'in-progress' | 'review' | 'done';
   priority: number;
-  assignee?: string;
-  persona?: string;
+  persona?: string; // Personas ARE the assignees - no separate assignee field
   tags: string[];
   createdAt: Date;
   updatedAt: Date;
@@ -38,7 +37,6 @@ export interface Persona {
 }
 
 export interface Filter {
-  assignee?: string;
   tags?: string[];
   persona?: string;
   status?: Task['status'];


### PR DESCRIPTION
Consolidates the dual assignee/persona concept into a single assignment mechanism where personas ARE the assignees.

## Changes:
- ✅ Remove separate `assignee` field from Task interface  
- ✅ Update FilterBar to filter by persona only, remove assignee filter
- ✅ Update TaskCard to show persona as assignee in header instead of footer
- ✅ Update TaskModal to use 'Assigned Persona' instead of separate assignee/persona fields
- ✅ Update CreateTaskModal to only have persona assignment field
- ✅ Remove unused getInitials function from TaskCard

## Benefits:
- Eliminates confusion between assignee vs persona concepts
- Simplifies UI with fewer form fields
- Makes the intent clear: personas (QA Engineer, Bug Fixer, etc.) are the workers
- Prepares for cron worker system that will use persona prompt files when spawning AI sessions

## Testing:
- All components updated consistently
- TypeScript interfaces align
- UI flows simplified (create task, edit task, filter tasks)