### PR TITLE
fix: remove duplicate TaskRating declaration

### DIFF
--- a/src/client/components/TaskRating.tsx
+++ b/src/client/components/TaskRating.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Task, TaskRating } from '../types';
+import { Task } from '../types';
 
 interface TaskRatingProps {
   task: Task;


### PR DESCRIPTION
The `TaskRating` type was imported from `../types` but never used in this file, and it shadowed the component's own `const TaskRating` declaration — causing a Babel compile error.\n\nRemoved the unused import.