### PR TITLE
fix: use Claude CLI instead of OpenClaw for AI responses

### DIFF
--- a/src/server/auto-review.ts
+++ b/src/server/auto-review.ts
@@ -172,8 +172,11 @@ async function spawnReviewSession(
     const tempPromptFile = path.join(os.tmpdir(), `tix-review-${task.id}.txt`);
     await fs.writeFile(tempPromptFile, reviewPrompt, 'utf8');
     
-    // Use OpenClaw CLI to run the review session
-    const { stdout, stderr } = await execAsync(`openclaw run --file "${tempPromptFile}" --timeout 180`);
+    // Use Claude CLI to run the review session
+    const { stdout, stderr } = await execAsync(
+      `cat "${tempPromptFile}" | claude --print`,
+      { timeout: 180000 } // 3 min timeout
+    );
     
     // Clean up temp file
     await fs.unlink(tempPromptFile).catch(() => {});

--- a/src/server/mention-handler.ts
+++ b/src/server/mention-handler.ts
@@ -68,10 +68,10 @@ async function generatePersonaResponse(originalMessage: ChatMessage, persona: Pe
     const tempPromptFile = path.join(os.tmpdir(), `tix-mention-${persona.id}-${Date.now()}.txt`);
     await fs.writeFile(tempPromptFile, contextPrompt, 'utf8');
     
-    // Use OpenClaw CLI with --print mode (no session persistence)
+    // Use Claude CLI with --print mode (no session persistence)
     const { stdout, stderr } = await execAsync(
-      `openclaw run --file "${tempPromptFile}" --print --timeout 60`,
-      { maxBuffer: 1024 * 1024 } // 1MB buffer for longer responses
+      `cat "${tempPromptFile}" | claude --print`,
+      { maxBuffer: 1024 * 1024, timeout: 60000 } // 1MB buffer, 60s timeout
     );
     
     // Clean up temp file

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -161,9 +161,11 @@ async function spawnAISession(task: Task, persona: Persona): Promise<{ output: s
     const tempPromptFile = path.join(os.tmpdir(), `tix-prompt-${task.id}.txt`);
     await fs.writeFile(tempPromptFile, prompt, 'utf8');
     
-    // Use OpenClaw CLI to run the session
-    // Note: This assumes OpenClaw is available in PATH and configured
-    const { stdout, stderr } = await execAsync(`openclaw run --file "${tempPromptFile}" --timeout 300`);
+    // Use Claude CLI to run the task
+    const { stdout, stderr } = await execAsync(
+      `cat "${tempPromptFile}" | claude --print`,
+      { timeout: 300000 } // 5 min timeout
+    );
     
     // Clean up temp file
     await fs.unlink(tempPromptFile).catch(() => {});


### PR DESCRIPTION
OpenClaw isn't installed locally — switches mention-handler, worker, and auto-review to use `claude --print` via stdin.