### PR TITLE
Fix Claude CLI timeout option - remove invalid --timeoutSeconds

### DIFF
--- a/src/server/auto-review.ts
+++ b/src/server/auto-review.ts
@@ -214,8 +214,8 @@ async function spawnReviewSession(
     // Use Claude CLI with prompt via stdin (secure approach - no temp files, no shell injection)
     const { stdout, stderr } = await executeClaudeWithStdin(
       reviewPrompt,
-      ['--allowedTools', 'Read,web_search,web_fetch', '--timeoutSeconds', '180'],
-      200000 // 3.3 min timeout (slightly longer than Claude timeout)
+      ['--allowedTools', 'Read,web_search,web_fetch'],
+      200000 // 3.3 min timeout (process-level timeout)
     );
     
     if (stderr) {

--- a/src/server/mention-handler.ts
+++ b/src/server/mention-handler.ts
@@ -71,8 +71,8 @@ async function generatePersonaResponse(originalMessage: ChatMessage, persona: Pe
     
     // Use Claude CLI in agentic mode for mention responses (using stdin to avoid shell injection)
     const { stdout, stderr } = await execAsync(
-      `cat "${tempPromptFile}" | claude -p --allowedTools Read,web_search --timeoutSeconds 60`,
-      { maxBuffer: 1024 * 1024, timeout: 70000 } // 1MB buffer, 70s timeout (slightly longer than Claude timeout)
+      `cat "${tempPromptFile}" | claude -p --allowedTools Read,web_search`,
+      { maxBuffer: 1024 * 1024, timeout: 70000 } // 1MB buffer, 70s timeout (process-level timeout)
     );
     
     // Clean up temp file

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -246,8 +246,8 @@ async function spawnAISession(task: Task, persona: Persona): Promise<{ output: s
     // Use Claude CLI with prompt via stdin (secure approach - no temp files, no shell injection)
     const { stdout, stderr } = await executeClaudeWithStdin(
       prompt, 
-      ['--allowedTools', 'Edit,exec,Read,Write', '--timeoutSeconds', '300'],
-      320000 // 5.3 min timeout (slightly longer than Claude timeout)
+      ['--allowedTools', 'Edit,exec,Read,Write'],
+      320000 // 5.3 min timeout (process-level timeout)
     );
     
     if (stderr) {


### PR DESCRIPTION
Cherry-picked from #26 (cleanly off master). Removes `--timeoutSeconds` which doesn't exist in Claude CLI — process-level timeouts already handle this.