### PR TITLE
[MLPEGXMH0BWDPC] Fix GitHub integration auth regex

### DIFF
--- a/src/server/github.ts
+++ b/src/server/github.ts
@@ -80,7 +80,8 @@ export async function saveGitHubConfig(config: GitHubConfig): Promise<void> {
 export async function testGitHubAuth(): Promise<{ authenticated: boolean; username?: string }> {
   try {
     const { stdout } = await exec('gh auth status --show-token 2>&1');
-    const usernameMatch = stdout.match(/Logged in to github\.com as ([^\s]+)/);
+    // Updated regex to match the actual output format: "Logged in to github.com account USERNAME"
+    const usernameMatch = stdout.match(/Logged in to github\.com account ([^\s]+)/);
     return {
       authenticated: true,
       username: usernameMatch ? usernameMatch[1] : undefined,


### PR DESCRIPTION
## Issue
The GitHub integration wasn't correctly extracting usernames from the `gh auth status` command output.

## Root Cause
The regex pattern in `testGitHubAuth()` was looking for:
`Logged in to github.com as USERNAME`

But the actual `gh` output format is:
`Logged in to github.com account USERNAME`

## Fix
- Updated regex from `/Logged in to github\.com as ([^\s]+)/` 
- To: `/Logged in to github\.com account ([^\s]+)/`

## Result
- `/api/github/auth` now correctly returns `{"authenticated": true, "username": "andywilliams"}`
- GitHub settings modal will properly show the authenticated username
- All other GitHub integration features tested and working

## Testing
- Verified auth endpoint returns username correctly
- Tested GitHub config save/load
- Verified PR/issue listing endpoints work
- Build passes successfully

Fixes task MLPEGXMH0BWDPC