### PR TITLE
fix: GitHub settings modal - scrolling, styling, per-repo branches

### DIFF
--- a/src/client/github.css
+++ b/src/client/github.css
@@ -26,6 +26,38 @@
 .github-settings-modal {
   width: 600px;
   max-width: 90vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary, #0f172a);
+  border: 1px solid var(--border, #334155);
+  border-radius: 0.75rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.github-settings-modal .modal-header {
+  flex-shrink: 0;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border, #334155);
+}
+
+.github-settings-modal .modal-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  max-height: none;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+}
+
+.github-settings-modal .modal-footer {
+  flex-shrink: 0;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--border, #334155);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
 }
 
 .github-settings-modal .section {
@@ -71,18 +103,26 @@
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
 }
 
+/* Section hint text */
+.section-hint {
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.8rem;
+  margin: 0 0 0.75rem 0;
+}
+
 /* Repository List */
 .repo-list {
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .repo-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem;
-  background: var(--color-background-secondary, #f9fafb);
-  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-tertiary, #1e293b);
+  border: 1px solid var(--border, #334155);
+  border-radius: 0.375rem;
   margin-bottom: 0.5rem;
 }
 
@@ -90,18 +130,45 @@
   margin-bottom: 0;
 }
 
+.repo-name {
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 0.85rem;
+  color: var(--text-primary, #e2e8f0);
+}
+
+.repo-item-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.repo-branch-select {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--border, #334155);
+  border-radius: 0.25rem;
+  background: var(--bg-secondary, #0f172a);
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
 .remove-btn {
-  background: var(--color-danger, #ef4444);
+  background: var(--error, #ef4444);
   color: white;
   border: none;
-  padding: 0.25rem 0.5rem;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 0.25rem;
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .remove-btn:hover {
-  background: var(--color-danger-dark, #dc2626);
+  background: #dc2626;
 }
 
 .add-repo {
@@ -112,21 +179,29 @@
 .add-repo input {
   flex: 1;
   padding: 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border, #334155);
   border-radius: 0.375rem;
+  background: var(--bg-secondary, #0f172a);
+  color: var(--text-primary, #e2e8f0);
+  font-size: 0.85rem;
+}
+
+.add-repo input::placeholder {
+  color: var(--text-muted, #64748b);
 }
 
 .add-repo button {
-  background: var(--color-primary, #3b82f6);
+  background: var(--accent, #3b82f6);
   color: white;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 0.375rem;
   cursor: pointer;
+  font-size: 0.85rem;
 }
 
 .add-repo button:hover {
-  background: var(--color-primary-dark, #2563eb);
+  background: var(--accent-hover, #2563eb);
 }
 
 /* Form Groups */
@@ -379,6 +454,39 @@
 .task-status {
   display: flex;
   align-items: center;
+}
+
+/* Modal footer buttons */
+.github-settings-modal .save-btn {
+  background: var(--accent, #3b82f6);
+  color: white;
+  border: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.github-settings-modal .save-btn:hover:not(:disabled) {
+  background: var(--accent-hover, #2563eb);
+}
+
+.github-settings-modal .save-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.github-settings-modal .cancel-btn {
+  background: transparent;
+  color: var(--text-secondary, #94a3b8);
+  border: 1px solid var(--border, #334155);
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+.github-settings-modal .cancel-btn:hover {
+  background: var(--bg-tertiary, #1e293b);
 }
 
 /* Dark mode adjustments */

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -82,9 +82,14 @@ export interface Filter {
   status?: Task['status'];
 }
 
+export interface RepoConfig {
+  name: string; // "owner/repo"
+  defaultBranch: string; // "main" or "master"
+}
+
 export interface GitHubConfig {
-  repos: string[]; // List of repo names like "owner/repo"
-  defaultBranch: string; // Default branch name (usually "main" or "master")
+  repos: (string | RepoConfig)[]; // List of repos — strings for backwards compat, or objects with per-repo settings
+  defaultBranch: string; // Fallback default branch for new repos
   branchPrefix: string; // Prefix for feature branches (e.g., "tix/")
   autoLink: boolean; // Auto-link tasks to PRs when created
 }


### PR DESCRIPTION
**Issues:**
1. Modal couldn't scroll — content overflowed viewport
2. Title cut off at top
3. Save/Cancel buttons hidden at bottom
4. Global default branch doesn't work when repos have different branches (e.g. main vs master)
5. Dark mode styling was off

**Fixes:**
- Flex layout with scrollable content area (max-height: 85vh)
- Per-repo default branch dropdown (main/master/develop)
- Dark mode consistent styling
- Backwards compatible — old string[] repos auto-normalize