### PR TITLE
feat: grant AI personas API access to kanban board

### DIFF
--- a/personas/builtin/developer.yaml
+++ b/personas/builtin/developer.yaml
@@ -23,6 +23,15 @@ prompt: |
 
   Write clean, maintainable code that follows established conventions.
 
+  ## Task Board Access
+
+  You have **read-only access** to the tix-kanban board via the API running on `localhost:3001`. Use `curl` via the `Bash` tool to query tasks:
+
+  - **List all tasks:** `curl -s http://localhost:3001/api/tasks`
+  - **Filter by status:** `curl -s http://localhost:3001/api/tasks?status=backlog`
+    - Valid statuses: `backlog`, `in-progress`, `review`, `done`
+  - **Get a single task:** `curl -s http://localhost:3001/api/tasks/<task-id>`
+
   ## Reminders
 
   You can create and receive reminders. You can set reminders for:

--- a/personas/builtin/product-manager.yaml
+++ b/personas/builtin/product-manager.yaml
@@ -102,11 +102,12 @@ prompt: |
 
   ## Task Board Access
 
-  You have **read-only access** to the tix-kanban task data directory. You can:
-  - Read task files to query backlog tickets and inspect task details
-  - List tasks and analyze board state, priorities, and assignments
+  You have **read-only access** to the tix-kanban board via the API running on `localhost:3001`. Use `curl` via the `Bash` tool to query tasks:
 
-  To list tasks, use `Bash` with `ls ~/.tix-kanban/tasks/`. To read a task file, use `Bash` with `cat ~/.tix-kanban/tasks/<task-id>.json`. Do not write or modify task files directly.
+  - **List all tasks:** `curl -s http://localhost:3001/api/tasks`
+  - **Filter by status:** `curl -s http://localhost:3001/api/tasks?status=backlog`
+    - Valid statuses: `backlog`, `in-progress`, `review`, `done`
+  - **Get a single task:** `curl -s http://localhost:3001/api/tasks/<task-id>`
 
   ## Reminders
 

--- a/personas/builtin/qa-engineer.yaml
+++ b/personas/builtin/qa-engineer.yaml
@@ -35,6 +35,15 @@ prompt: |
 
   Be thorough but fair. Approve work that meets standards, reject work that has significant issues. Provide specific, actionable feedback.
 
+  ## Task Board Access
+
+  You have **read-only access** to the tix-kanban board via the API running on `localhost:3001`. Use `curl` via the `Bash` tool to query tasks:
+
+  - **List all tasks:** `curl -s http://localhost:3001/api/tasks`
+  - **Filter by status:** `curl -s http://localhost:3001/api/tasks?status=backlog`
+    - Valid statuses: `backlog`, `in-progress`, `review`, `done`
+  - **Get a single task:** `curl -s http://localhost:3001/api/tasks/<task-id>`
+
   ## Reminders
 
   You can create and receive reminders. You can set reminders for:

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -280,9 +280,13 @@ app.get('/api/health', (_req, res) => {
 // Task API routes
 
 // GET /api/tasks - Get all tasks
-app.get('/api/tasks', async (_req, res) => {
+app.get('/api/tasks', async (req, res) => {
   try {
-    const tasks = await getAllTasks();
+    let tasks = await getAllTasks();
+    const status = req.query.status as string | undefined;
+    if (status) {
+      tasks = tasks.filter(task => task.status === status);
+    }
     res.json({ tasks });
   } catch (error) {
     console.error('GET /api/tasks error:', error);


### PR DESCRIPTION
## Summary
- Added `?status=` query parameter to `GET /api/tasks` endpoint for filtering tasks by status (backlog, in-progress, review, done)
- Updated product-manager, developer, and qa-engineer persona instructions to use `curl http://localhost:3001/api/tasks` API calls instead of filesystem `ls`/`cat` commands
- No new tools or permissions needed — `curl` works via the existing `Bash` tool in the worker sandbox

## Test plan
- [ ] Verify `curl http://localhost:3001/api/tasks` returns all tasks
- [ ] Verify `curl http://localhost:3001/api/tasks?status=backlog` returns only backlog tasks
- [ ] Verify persona instructions render correctly in worker context
- [ ] Verify no regression on existing task API functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backwards-compatible API enhancement plus documentation/prompt updates; main concern is ensuring the new `status` query param doesn’t change default task listing behavior.
> 
> **Overview**
> Enables AI personas to read the kanban board via `curl` against the local `localhost:3001` API rather than filesystem access.
> 
> `GET /api/tasks` now accepts an optional `?status=` query parameter to return only tasks matching a given status, while preserving the existing unfiltered response when omitted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77c0bbdff17b2dd48dc75eaa0277142ffec0640d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->